### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/InteractiveFigures/InDevelopment/Cepheids_3D/3DCepheids.ipynb
+++ b/InteractiveFigures/InDevelopment/Cepheids_3D/3DCepheids.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "Notebook and script based on `dices.py` created by F. Vogt ([email](mailto:frederic.vogt@anu.edu.au)), January 2015. \n",
     "\n",
-    "Please cite Vogt et al. (2014) ([doi:10.1088/0004-637X/793/2/127/data](http://dx.doi.org/10.1088/0004-637X/793/2/127/data)) as the first instance of this type of data object in an AAS Journal article.\n",
+    "Please cite Vogt et al. (2014) ([doi:10.1088/0004-637X/793/2/127/data](https://doi.org/10.1088/0004-637X/793/2/127/data)) as the first instance of this type of data object in an AAS Journal article.\n",
     "\n",
     "History: \n",
     "> April 2015: Initial version, August Muench (august.fly@gmail.com)\n"

--- a/Repositories/CitingRepositories.md
+++ b/Repositories/CitingRepositories.md
@@ -8,7 +8,7 @@ This tutorial details how to cite repositories in your manuscript. The AAS Journ
 
     {author*} {year}, {title}, {version^}, {publisher|howpublished~}, {prefix}:{identifier#}
 
-  To illustrate and document this format, we use a corresponding BibTeX entry taken and modified from a [real example](http://dx.doi.org/10.5281/zenodo.15991)). Note that all data/software BibTeX entries should be of the `@misc` type: 
+  To illustrate and document this format, we use a corresponding BibTeX entry taken and modified from a [real example](https://doi.org/10.5281/zenodo.15991)). Note that all data/software BibTeX entries should be of the `@misc` type: 
 
     @misc{lia_corrales_2015_15991,
         author       = {Lia Corrales},
@@ -62,7 +62,7 @@ At the moment these BibTeX results can lack the requisite fields, e.g., version.
   ```
 
   ```
-  \citep[][Dataset: \url{http://doi.org/10.5281/zenodo.15991}]{lia_corrales_2015_15991}
+  \citep[][Dataset: \url{https://doi.org/10.5281/zenodo.15991}]{lia_corrales_2015_15991}
   ```
   
   


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!


PS: Regarding the `all data/software BibTeX entries should be of the `@misc` type`, https://github.com/zenodo/zenodo/issues/1428#issuecomment-398781531 might be of interest.